### PR TITLE
Improve Helm chart usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ $ helm install cloudhealth-collector --set apiToken=<Unique Customer API Token>,
 
 These commands deploy the CloudHealth Collector on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
 
+The `apiToken` is required for `cloudhealth-collector` to work properly and should be either set explicitely as in the example above or in a secret object with the following data structure:
+```yaml
+data:
+  apiToken:  "PGNoYW5nZS1tZT4="
+  clusterName: "eW91ci1jbHVzdGVyLW5hbWU="
+```
+
+The secret name should be provided via the `secretName` parameter unless it follows the default value.
+
 > **Tip**: List all releases using `helm list`
 
 ## Uninstalling the Chart
@@ -51,7 +60,6 @@ $ helm repo remove cloudhealth
 
 | Name                     | Description                                                                             | Value           |
 | ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
-| `apiToken`            | Unique Customer API Token provided by CloudHealth                                                             | `<change-me>`            |
 | `clusterName`           | Name of the cluster to be shown on the CloudHealth UI                                      | `your-cluster-name`            |
 
 
@@ -59,6 +67,7 @@ $ helm repo remove cloudhealth
 
 | Name                        | Description                                                                                  | Value                 |
 | --------------------------- | -------------------------------------------------------------------------------------------- | --------------------- |
+| `apiToken`            | Unique Customer API Token provided by CloudHealth                                                             | `<change-me>`            |
 | `image.repository`          | CloudHealth Collector image repository                                                            | `cloudhealth/container-collector`      |
 | `image.tag`                 | CloudHealth Collector image tag (immutable tags are recommended)                                  | `latest` |
 | `image.pullPolicy`          | CloudHealth Collector image pull policy                                                           | `Always`        |
@@ -105,5 +114,3 @@ Find more information about how to deal with common errors related to CloudHealt
 - https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
 - https://helm.sh/docs/topics/v2_v3_migration/
 - https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
-
-

--- a/cloudhealth-collector/Chart.yaml
+++ b/cloudhealth-collector/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/cloudhealth-collector/templates/clusterrolebinding.yaml
+++ b/cloudhealth-collector/templates/clusterrolebinding.yaml
@@ -13,7 +13,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "cloudhealth-collector.fullname" . }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "cloudhealth-collector.fullname" . }}

--- a/cloudhealth-collector/templates/secrets.yaml
+++ b/cloudhealth-collector/templates/secrets.yaml
@@ -3,6 +3,7 @@ Copyright 2021 VMware, Inc.
 SPDX-License-Identifier: Apache-2.0
 */}}
 
+{{- if .Values.apiToken }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ type: Opaque
 data:
   apiToken:  {{ .Values.apiToken | b64enc | quote }}
   clusterName: {{ .Values.clusterName | b64enc | quote }}
+{{- end }}

--- a/cloudhealth-collector/values.yaml
+++ b/cloudhealth-collector/values.yaml
@@ -7,7 +7,7 @@
 
 replicaCount: 1
 
-apiToken: <change-me>
+apiToken: ""
 clusterName: your-cluster-name
 
 collectionIntervalSecs: 900
@@ -51,7 +51,7 @@ service:
   type: ClusterIP
   port: 80
 
-resources: 
+resources:
   limits:
     cpu: 1000m
     memory: 1024Mi


### PR DESCRIPTION
- make `apiToken` optional and create secret conditionally - gives the ability to create secret object outside of the helm chart so it's not exposed in CaaC repository or pipelines
- use `.Release.Namespace` for mapping ServiceAccount to be able deploy in namespaces other than `default`, fixes #7 