### PR TITLE
[cloudhealth-collector] add support for podAnnotations

### DIFF
--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       {{- include "cloudhealth-collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "cloudhealth-collector.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
`podAnnotations` are actually listed in the `README.md` -> https://github.com/CloudHealth/helm/blob/main/README.md#other-parameters
and also in the default `values.yaml`
https://github.com/CloudHealth/helm/blob/main/cloudhealth-collector/values.yaml#L37
but they have not been implemented in the chart.

this PR implements the missing functionality

Signed-off-by: smcavallo <smcavallo@hotmail.com>