### PR TITLE
additional labels and service account annotations

### DIFF
--- a/cloudhealth-collector/Chart.yaml
+++ b/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "2.0.175"
 home: https://cloudhealth.vmware.com/
 sources:

--- a/cloudhealth-collector/templates/_helpers.tpl
+++ b/cloudhealth-collector/templates/_helpers.tpl
@@ -42,6 +42,9 @@ helm.sh/chart: {{ include "cloudhealth-collector.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -67,6 +70,6 @@ Create the name of the service account to use
 {{/*
 Create the name of the secrets to use
 */}}
-{{- define "cloudhealth-collector.secret.name" -}}
-{{- default .Values.secret.name }}
+{{- define "cloudhealth-collector.secretName" -}}
+{{- default .Values.secretName }}
 {{- end }}

--- a/cloudhealth-collector/templates/_helpers.tpl
+++ b/cloudhealth-collector/templates/_helpers.tpl
@@ -67,6 +67,6 @@ Create the name of the service account to use
 {{/*
 Create the name of the secrets to use
 */}}
-{{- define "cloudhealth-collector.secretName" -}}
-{{- default .Values.secretName }}
+{{- define "cloudhealth-collector.secret.name" -}}
+{{- default .Values.secret.name }}
 {{- end }}

--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -33,16 +33,24 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            {{- if .Values.secret.enabled }}
             - name: CHT_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloudhealth-collector.secretName" . }}
+                  name: {{ include "cloudhealth-collector.secret.name" . }}
                   key: apiToken
             - name: CHT_CLUSTER_NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloudhealth-collector.secretName" . }}
+                  name: {{ include "cloudhealth-collector.secret.name" . }}
                   key: clusterName
+            {{- end }}
+            {{- if not .Values.secret.enabled }}
+            - name: CHT_API_TOKEN
+              value: {{ .Values.apiToken | quote }}
+            - name: CHT_CLUSTER_NAME
+              value: {{ .Values.clusterName | quote }}
+            {{- end }}
             - name: CHT_INTERVAL
               value: {{ .Values.collectionIntervalSecs | quote }}
             - name: CHT_JVM_MEM

--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "cloudhealth-collector.selectorLabels" . | nindent 8 }}
+        {{- include "cloudhealth-collector.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudhealth-collector.serviceAccountName" . }}
       containers:
@@ -33,24 +33,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            {{- if .Values.secret.enabled }}
             - name: CHT_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloudhealth-collector.secret.name" . }}
+                  name: {{ include "cloudhealth-collector.secretName" . }}
                   key: apiToken
             - name: CHT_CLUSTER_NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "cloudhealth-collector.secret.name" . }}
+                  name: {{ include "cloudhealth-collector.secretName" . }}
                   key: clusterName
-            {{- end }}
-            {{- if not .Values.secret.enabled }}
-            - name: CHT_API_TOKEN
-              value: {{ .Values.apiToken | quote }}
-            - name: CHT_CLUSTER_NAME
-              value: {{ .Values.clusterName | quote }}
-            {{- end }}
             - name: CHT_INTERVAL
               value: {{ .Values.collectionIntervalSecs | quote }}
             - name: CHT_JVM_MEM

--- a/cloudhealth-collector/templates/secrets.yaml
+++ b/cloudhealth-collector/templates/secrets.yaml
@@ -2,14 +2,15 @@
 Copyright 2021 VMware, Inc.
 SPDX-License-Identifier: Apache-2.0
 */}}
-
+{{- if .Values.secret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cloudhealth-collector.secretName" . }}
+  name: {{ include "cloudhealth-collector.secret.name" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
 type: Opaque
 data:
   apiToken:  {{ .Values.apiToken | b64enc | quote }}
   clusterName: {{ .Values.clusterName | b64enc | quote }}
+{{- end }}

--- a/cloudhealth-collector/templates/secrets.yaml
+++ b/cloudhealth-collector/templates/secrets.yaml
@@ -2,15 +2,14 @@
 Copyright 2021 VMware, Inc.
 SPDX-License-Identifier: Apache-2.0
 */}}
-{{- if .Values.secret.enabled }}
+
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cloudhealth-collector.secret.name" . }}
+  name: {{ include "cloudhealth-collector.secretName" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
 type: Opaque
 data:
   apiToken:  {{ .Values.apiToken | b64enc | quote }}
   clusterName: {{ .Values.clusterName | b64enc | quote }}
-{{- end }}

--- a/cloudhealth-collector/templates/serviceaccount.yaml
+++ b/cloudhealth-collector/templates/serviceaccount.yaml
@@ -10,9 +10,9 @@ metadata:
   name: {{ include "cloudhealth-collector.serviceAccountName" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
-{{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-{{- end }}
+  {{- end }}
 automountServiceAccountToken: true
 {{- end }}

--- a/cloudhealth-collector/templates/serviceaccount.yaml
+++ b/cloudhealth-collector/templates/serviceaccount.yaml
@@ -10,5 +10,9 @@ metadata:
   name: {{ include "cloudhealth-collector.serviceAccountName" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 automountServiceAccountToken: true
 {{- end }}

--- a/cloudhealth-collector/values.yaml
+++ b/cloudhealth-collector/values.yaml
@@ -23,9 +23,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-secret:
-  enabled: true
-  name: cloudhealth-config
+secretName: cloudhealth-config
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -35,6 +33,9 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+
+# Additional labels to add to all resources created by this chart
+additionalLabels: {}
 
 podAnnotations: {}
 

--- a/cloudhealth-collector/values.yaml
+++ b/cloudhealth-collector/values.yaml
@@ -23,7 +23,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-secretName: cloudhealth-config
+secret:
+  enabled: true
+  name: cloudhealth-config
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Hi CloudHealth team. 

Proposed changes:

- Fix: add service account annotations to service account - there is a value for this option but currently no annotations can be added.
- Feature: added value `additionalLabels`, which is included in common labels (`cloudhealth-collector.labels`) and propagated to all resources created by this chart. This is required for internal tooling we have developed.

Test Plan and Risk Assessment:

How did you test this locally?

- Deployed to [KinD](https://github.com/kubernetes-sigs/kind) local cluster to test and validate changes to the chart.
- Deployed chart to an AWS EKS (1.21) cluster to confirm the agent worked with internal tooling and connected/sent data to CloudHealth.
