### PR TITLE
[cloudhealth-collector] Add support for customLabels to chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ $ helm repo remove cloudhealth
 | `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
 | `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
 | `tolerations`                           | Tolerations for pod assignment                                                            | `[]`            |
+| `customLabels`                          | Custom labels to for resources                                                  | `{}` |  
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example, the following command sets the CloudHealth Collector API Token to `sample_token` and sets the cluster name to `mega-cluster`.

--- a/cloudhealth-collector/Chart.yaml
+++ b/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for Kubernetes
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "2.0.175"
 home: https://cloudhealth.vmware.com/
 sources:

--- a/cloudhealth-collector/templates/_helpers.tpl
+++ b/cloudhealth-collector/templates/_helpers.tpl
@@ -43,6 +43,9 @@ helm.sh/chart: {{ include "cloudhealth-collector.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       {{- end }}
       labels:
         {{- include "cloudhealth-collector.selectorLabels" . | nindent 8 }}
+        {{- include "cloudhealth-collector.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudhealth-collector.serviceAccountName" . }}
       containers:

--- a/cloudhealth-collector/values.yaml
+++ b/cloudhealth-collector/values.yaml
@@ -11,6 +11,7 @@ apiToken: ""
 clusterName: ""
 
 collectionIntervalSecs: 900
+customLabels: {}
 jvmMemory: "-Xmx891M"
 
 image:


### PR DESCRIPTION
This PR adds support to apply customLabels to all resources that template out cloudhealth-collector.labels. This is often required for tagging or governance purposes.