### PR TITLE
[CHE-202] Add namespace label beta instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ $ helm repo add cloudhealth https://cloudhealth.github.io/helm/
 $ helm install cloudhealth-collector --set apiToken=<Unique Customer API Token>,clusterName=<Cluster Name> cloudhealth/cloudhealth-collector
 ```
 
+`BETA` To allow the collector agent to also collect namespace resources, run the above command with following `devArgs` set:
+```console
+$ helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\]" cloudhealth/cloudhealth-collector
+```
+
 To install the chart with the release name `cloudhealth-collector` in a particular namespace `<target_namespace>`, run the following command:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ helm repo add cloudhealth https://cloudhealth.github.io/helm/
 $ helm install cloudhealth-collector --set apiToken=<Unique Customer API Token>,clusterName=<Cluster Name> cloudhealth/cloudhealth-collector
 ```
 
-`BETA` To allow the collector agent to also collect namespace resources, run the above command with following `devArgs` set:
+`BETA` To allow the collector agent to also collect namespace resources, run the above command with the following `devArgs` set:
 ```console
 $ helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\]" cloudhealth/cloudhealth-collector
 ```

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ $ helm repo add cloudhealth https://cloudhealth.github.io/helm/
 $ helm install cloudhealth-collector --set apiToken=<Unique Customer API Token>,clusterName=<Cluster Name> cloudhealth/cloudhealth-collector
 ```
 
-`BETA` To allow the collector agent to also collect namespace resources, run the above command with the following `devArgs` set:
-```console
-$ helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\]" cloudhealth/cloudhealth-collector
-```
-
-To install the chart with the release name `cloudhealth-collector` in a particular namespace `<target_namespace>`, run the following command:
+To install the chart with the release name `cloudhealth-collector` in a particular namespace `<target_namespace>`, run the following commands:
 
 ```console
 $ helm repo add cloudhealth https://cloudhealth.github.io/helm/
 $ helm install cloudhealth-collector -n <target_namespace> --set apiToken=<Unique Customer API Token>,clusterName=<Cluster Name> cloudhealth/cloudhealth-collector
+```
+
+`BETA` To allow the collector agent to also collect namespace resources, add the following `devArgs` when running the above `install` command:
+```console
+--set devArgs="\['upload_k8s_state_v2'\,'--verbose'\]"
 ```
 
 The `apiToken` is required for `cloudhealth-collector` to work and should be either set while running helm install command as in the example above or in a secret object with the following data structure:


### PR DESCRIPTION
Adding instructions for deploying the agent with the public beta namespace instructions.