### PR TITLE
#37 securityContext is in values.yaml but not in deployment.yaml

### DIFF
--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -26,12 +26,19 @@ spec:
         {{- include "cloudhealth-collector.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudhealth-collector.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmpfs
           env:
             - name: CHT_API_TOKEN
               valueFrom:
@@ -57,3 +64,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: tmpfs
+          emptyDir: {}


### PR DESCRIPTION
Add the `securityContext` option to the `deployment.yaml` template file to be able to use override values in the `values.yaml` file (lines 42-48. 

Note: In order to be able to use the `readOnlyRootFilesystem: true`  option, I had to add an `emptyDir` volume to the template for the` /tmp` directory in the container, otherwise, the Collector application would throw the following error:

`ERROR: java.io.IOException: read-only file system`

The `securityContext` values tested were the default ones:

> securityContext:
>   capabilities:
>     drop:
>     - ALL
>   readOnlyRootFilesystem: true
>   runAsNonRoot: true
>  runAsUser: 1000

