### PR TITLE
[SDO-1926] update changelog for removing rollbar triggering

### DIFF
--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,7 +10,7 @@ The agent has been verified against:
 
 ## [1201] - 2022-08-09
 ### Removed
-* Removed errors requests
+* Removed triggering requests to errors endpoint
 
 ## [1191] - 2022-07-25
 ### Added

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -8,6 +8,10 @@ The agent has been verified against:
 [Kubernetes Versions ≤ 1.23](https://kubernetes.io/releases/)</br>
 [OC Version ≥ 4.1](https://docs.openshift.com/container-platform)
 
+## [1201] - 2022-08-09
+### Removed
+* Removed errors requests
+
 ## [1191] - 2022-07-25
 ### Added
 * Functionality to collect additional resources from the Kubernetes API including:


### PR DESCRIPTION
Update changelog for version 1201, which removed sending agent errors to the collection errors endpoint.