### PR TITLE
adding option create custom annotations for cloudhealth deployment

### DIFF
--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ include "cloudhealth-collector.fullname" . }}
   labels:
     {{- include "cloudhealth-collector.labels" . | nindent 4 }}
+  {{- with .Values.deployAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/cloudhealth-collector/values.yaml
+++ b/cloudhealth-collector/values.yaml
@@ -35,6 +35,8 @@ serviceAccount:
 # Custom labels to add to all resources created by this chart
 customLabels: {}
 
+deployAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Hello Cloud health team.

In my organization, there is a set of mandatory annotations that need to be included on each deployment and the current helm chart do not allow a standard way to have those annotations so I'm creating this PR for your consideration and evaluation.

Marco.