### PR TITLE
fix: dnsConfig collission with nodeSelector context

### DIFF
--- a/cloudhealth-collector/Chart.yaml
+++ b/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 2.0.7
+version: 2.0.8
 appVersion: "3.2.3"
 home: https://cloudhealth.vmware.com/
 sources:

--- a/cloudhealth-collector/templates/deployment.yaml
+++ b/cloudhealth-collector/templates/deployment.yaml
@@ -26,8 +26,8 @@ spec:
         {{- include "cloudhealth-collector.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "cloudhealth-collector.serviceAccountName" . }}
-      {{- with .Values.podSecurityContext }} 
-      securityContext: {{- toYaml . | nindent 8 }} 
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -44,13 +44,13 @@ spec:
             initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.liveness.failureThreshold }}
             periodSeconds: {{ .Values.liveness.periodSeconds }}
-          {{- with .Values.containerSecurityContext }} 
-          securityContext: {{- toYaml . | nindent 12 }} 
+          {{- with .Values.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
-          volumeMounts: 
-            - mountPath: /tmp 
-              name: tmpfs 
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmpfs
           {{- end }}
           env:
             - name: CHT_API_TOKEN
@@ -69,18 +69,18 @@ spec:
               value: {{ .value }}
             {{- end }}
           args: {{ .Values.devArgs }}
-      {{- with .Values.nodeSelector }}
 
       # Modify /etc/resolv.conf ndots
       {{ if .Values.dnsConfig }}
-          dnsConfig:
+      dnsConfig:
       {{- if .Values.dnsConfig.ndots }}
-            options:
-              - name: ndots
-                value: {{ .Values.dnsConfig.ndots | quote}}
+        options:
+          - name: ndots
+            value: {{ .Values.dnsConfig.ndots | quote}}
       {{- end }}
       {{- end }}
 
+      {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -92,8 +92,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }} 
-      volumes: 
-        - name: tmpfs 
-          emptyDir: {} 
+      {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
+      volumes:
+        - name: tmpfs
+          emptyDir: {}
       {{- end }}


### PR DESCRIPTION
The `dnsConfig` value injection was accidentally embedded in the `with` context for `nodeSelector`.