### PR TITLE
FIX[98]: Update Image Tag to 1360

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.0.0
+version: 4.0.1
 appVersion: "5.0.0"
 home: https://cloudhealth.vmware.com/
 sources:

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -26,7 +26,7 @@ jvmMemory: "-Xmx891M"
 
 image:
   repository: cloudhealth/container-collector
-  tag: "1325"
+  tag: "1360"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Why do we need this change?
=======================
As part of the changes made for the 4.0.0 release a new container was released and properties were set for it, however we forgot to update the tag in the values.yaml so folks got the new behaviors

What effects does this change have?
=======================
* Updates Image Tag to the 1360 build released this week