### PR TITLE
Adding icon and category for TMC catalog

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,8 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-category: Cost
+annotations:
+  category: Cost
 version: 4.1.0
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg
 appVersion: "5.0.0"

--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -7,7 +7,7 @@ description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
 category: Cost
 version: 4.1.0
-icon: https://cloudsolutions.vmware.com/content/dam/digitalmarketing/vmware/en/images/gallery/icons/icon-prod-vmw-aria-cost-rgb-400px.svg
+icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg
 appVersion: "5.0.0"
 home: https://cloudhealth.vmware.com/
 sources:

--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,9 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
+category: Cost
 version: 4.1.0
+icon: https://cloudsolutions.vmware.com/content/dam/digitalmarketing/vmware/en/images/gallery/icons/icon-prod-vmw-aria-cost-rgb-400px.svg
 appVersion: "5.0.0"
 home: https://cloudhealth.vmware.com/
 sources:


### PR DESCRIPTION
Currently, adding Cloudhealth helm repo shows the cloudhealth-collector helm chart but displays no category (can't sort) and no icon like all of the bitnami repos do. This should change that.

<img width="556" alt="Screenshot 2023-10-19 at 2 53 25 PM" src="https://github.com/CloudHealth/helm/assets/7721068/953e3d2e-819d-43c0-852a-cb45d7c04bc6">
