### PR TITLE
[SDO-2756] Clarify chtRegion param description

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ helm repo remove cloudhealth
 | Name                        | Description                                                                                       | Value                             |
 |-----------------------------|---------------------------------------------------------------------------------------------------|-----------------------------------|
 | `apiToken`                  | Unique Customer API Token provided by CloudHealth                                                 | `""`                              |
-| `chtRegion`                 | CloudHealth Region provided by CloudHealth (CloudHealth region where customer is onboarded)       | `us-east-1`                       |
+| `chtRegion`                 | Region provided by CloudHealth (region where VMware Tanzu CloudHealth account is onboarded)       | `us-east-1`                       |
 | `image.repository`          | CloudHealth Collector image repository                                                            | `cloudhealth/container-collector` |
 | `image.tag`                 | CloudHealth Collector image tag                                                                   | `1398`                            |
 | `image.pullPolicy`          | CloudHealth Collector image pull policy                                                           | `IfNotPresent`                    |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ helm repo remove cloudhealth
 | Name                        | Description                                                                                       | Value                             |
 |-----------------------------|---------------------------------------------------------------------------------------------------|-----------------------------------|
 | `apiToken`                  | Unique Customer API Token provided by CloudHealth                                                 | `""`                              |
-| `chtRegion`                 | CloudHealth Region (It has to be a valid AWS Region Code)                                         | `us-east-1`                       |
+| `chtRegion`                 | CloudHealth Region provided by CloudHealth (CloudHealth region where customer is onboarded)       | `us-east-1`                       |
 | `image.repository`          | CloudHealth Collector image repository                                                            | `cloudhealth/container-collector` |
 | `image.tag`                 | CloudHealth Collector image tag                                                                   | `1398`                            |
 | `image.pullPolicy`          | CloudHealth Collector image pull policy                                                           | `IfNotPresent`                    |


### PR DESCRIPTION
[SDO-2756](https://cloudhealthtech.atlassian.net/browse/SDO-2756)

The chart already has schema matching in place to prevent bad input:
```
kschermerhor@kschermerhP0294 ~ % helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtRegion=$CHT_REGION cloudhealth/cloudhealth-collector
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
cloudhealth-collector:
- chtRegion: Does not match pattern '^(us-east-1|us-east-2)$'
```

This PR is to make the description more clear.

[SDO-2756]: https://cloudhealthtech.atlassian.net/browse/SDO-2756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ