### PR TITLE
fix values json schema for apiToken

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.2.1
+version: 4.2.2
 appVersion: "5.1.1"
 home: https://cloudhealth.vmware.com/
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg

--- a/charts/cloudhealth-collector/values.schema.json
+++ b/charts/cloudhealth-collector/values.schema.json
@@ -2,7 +2,6 @@
     "$schema": "https://json-schema.org/draft-07/schema#",
     "type": "object",
     "required": [
-        "apiToken",
         "clusterName",
         "chtRegion",
         "collectionIntervalSecs",


### PR DESCRIPTION
remove `apiToken` as a required value in the values json schema.
It is not a required value - https://github.com/CloudHealth/helm/blob/main/charts/cloudhealth-collector/templates/secrets.yaml#L6-L16
If it is set, this chart will create the `cloudhealth-config` secret.
If it is not set, end users can manage their own `cloudhealth-config` secrets and values outside of this chart (which most may want to do for security reasons.)

This chart is currently broken for anyone managing their own secret:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudhealth-collector:
- apiToken: Does not match pattern '^.{6,48}$'
```

This fixes that by making  `apiToken`  not required.

Signed-off-by: smcavallo <smcavallo@hotmail.com>