### PR TITLE
fix values json schema for apiToken

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.3.0
+version: 4.3.1
 appVersion: "5.2.0"
 home: https://cloudhealth.vmware.com/
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg

--- a/charts/cloudhealth-collector/values.schema.json
+++ b/charts/cloudhealth-collector/values.schema.json
@@ -17,8 +17,13 @@
     ],
     "properties": {
         "apiToken": {
-            "type": "string",
-            "pattern": "^.{6,48}$"
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "pattern": "^(.{6,48}|)$"
+                }
+            ]
         },
         "clusterName": {
             "type": "string",


### PR DESCRIPTION

Unfortunately https://github.com/CloudHealth/helm/pull/108 did not fix the issue.
String is not a required field but the json schema requires that there is a type of `apiToken` and that it must be a string and must match the given pattern.  The intention is to only match the given pattern if the `apiToken` is provided.

This PR fixes that.
Output of testing which was performed is below.


# null value succeeds
```
helm template --values=values.yaml . > /dev/null
```

# string less than 6 characters fails
```
helm template --values=values.yaml --set cloudhealth-collector.apiToken=asf . > /dev/null
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudhealth-collector:
- apiToken: Must validate at least one schema (anyOf)
- apiToken: Does not match pattern '^(.{6,48}|)$'
```

# string longer than 6 characters succeeds
```
helm template --values=values.yaml --set cloudhealth-collector.apiToken=12345s . > /dev/null
```

# string which is 48 characters succeeds
```
helm template --values=values.yaml --set cloudhealth-collector.apiToken=123456789012345678901234567890123456789012345678 . > /dev/null
```

# string which is longer than 48 characters fails
```
helm template --values=values.yaml --set cloudhealth-collector.apiToken=1234567890123456789012345678901234567890123456789 . > /dev/null
Error: values don't meet the specifications of the schema(s) in the following chart(s):
cloudhealth-collector:
- apiToken: Must validate at least one schema (anyOf)
- apiToken: Does not match pattern '^(.{6,48}|)$'
```