### PR TITLE
cloudhealth-collector pod gets restarted due to emptydir

### DIFF
--- a/charts/cloudhealth-collector/templates/deployment.yaml
+++ b/charts/cloudhealth-collector/templates/deployment.yaml
@@ -124,7 +124,8 @@ spec:
       {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
       volumes:
         - name: tmpfs
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 500Mi
         {{- if .Values.proxy.sslCert }}
         - name: truststore-volume
           emptyDir: {}


### PR DESCRIPTION
Currently there’s no limit for the amount of memory the emptydir can consume, according to https://github.com/kubernetes/kubernetes/issues/119611 this may end up crashing the node as the memory limit is not being considered when using emptydir (the emptydir can consume all the memory of the node, resulting in other processes being killed). Setting the limit to half of the allocated memory should be fine.