### PR TITLE
[SDO-2961] Update controller dependency to JFrog repo

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector and Optimizer Agent
 type: application
-version: 5.9.1-beta
+version: 6.0.0-beta
 appVersion: "7.0.0"
 dependencies:
   - name: k8s-optimization

--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -9,7 +9,7 @@ version: 5.9.1-beta
 appVersion: "7.0.0"
 dependencies:
   - name: k8s-optimization
-    repository: oci://projects.registry.vmware.com/kubernetes-optimization
+    repository: oci://projects.packages.broadcom.com/kubernetes-optimization
     version: 1.1.1
     condition: optimizer.enabled
 home: https://cloudhealth.vmware.com/


### PR DESCRIPTION
[SDO-2961](https://cloudhealthtech.atlassian.net/browse/SDO-2961)

Ran `helm dependency build` to ensure it pulled the correct package:
```
kschermerhor@kschermerhP0294 helm % helm dependency build charts/cloudhealth-collector
Hang tight while we grab the latest from your chart repositories...
...Unable to get an update from the "cht" chart repository (https://artifactory.mgmt.cloudhealthtech.com/artifactory/helm-virtual):
        Get "https://artifactory.mgmt.cloudhealthtech.com/artifactory/helm-virtual/index.yaml": dial tcp: lookup artifactory.mgmt.cloudhealthtech.com: no such host
...Successfully got an update from the "cloudhealth" chart repository
...Successfully got an update from the "telegraf" chart repository
...Successfully got an update from the "rabbitmq" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading k8s-optimization from repo oci://projects.packages.broadcom.com/kubernetes-optimization
Pulled: projects.packages.broadcom.com/kubernetes-optimization/k8s-optimization:1.1.1
Digest: sha256:60d00a07d61ea5e18aa5c1c9ee562f89bf6311f33e24128b498779696fa82491
Deleting outdated charts
```

[SDO-2961]: https://cloudhealthtech.atlassian.net/browse/SDO-2961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ