### PR TITLE
[SDO-3026] Update Collector Image for Security Vulnerabilities

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.6.3
-appVersion: "7.0.0"
+version: 4.6.4
+appVersion: "7.1.0"
 home: https://cloudhealth.vmware.com/
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg
 sources:

--- a/charts/cloudhealth-collector/NOTES.txt
+++ b/charts/cloudhealth-collector/NOTES.txt
@@ -10,24 +10,24 @@ helm install cloudhealth-collector --debug --dry-run --set apiToken=$CHT_API_TOK
 
 To install helm for local collection dev testing:
 
-helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
+helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
 
-helm upgrade cloudhealth-collector -n dmz --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\]" cloudhealth/cloudhealth-collector
+helm upgrade cloudhealth-collector -n dmz --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\]" cloudhealth/cloudhealth-collector
 
 helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=cloudhealth/container-collector-dev cloudhealth/cloudhealth-collector
 
 
-helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
+helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
 
-helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=metrics-collector-1,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
-helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-1,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
+helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=metrics-collector-1,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
+helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-1,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" cloudhealth/cloudhealth-collector
 
 
 --set "customEnvVars[0].name=ENV4" --set "customEnvVars[0].value=VALUE4"
 
-upload_k8s_state_v2 --verbose --endpoint http://<your_ip_address>:9292
+upload_k8s_state_v4 --verbose --endpoint http://<your_ip_address>:9292
 
 
-helm install cloudhealth-collector --debug --dry-run --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-06-13-3,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]",podSecurityContext.fsGroup=2000,containerSecurityContext.readOnlyRootFilesystem=true,containerSecurityContext.runAsNonRoot=true,containerSecurityContext.runAsUser=1000,containerSecurityContext.capabilities.drop={ALL} ./cloudhealth-collector-1.1.3.tgz
+helm install cloudhealth-collector --debug --dry-run --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-06-13-3,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]",podSecurityContext.fsGroup=2000,containerSecurityContext.readOnlyRootFilesystem=true,containerSecurityContext.runAsNonRoot=true,containerSecurityContext.runAsUser=1000,containerSecurityContext.capabilities.drop={ALL} ./cloudhealth-collector-1.1.3.tgz
 
-helm install cloudhealth-collector --debug --dry-run --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-06-13-3,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v2'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" --set "customEnvVars[0].name=ENV4" --set "customEnvVars[0].value=VALUE4" --set serviceAccount.name=sample_service_account ./cloudhealth-collector-1.1.2.tgz
+helm install cloudhealth-collector --debug --dry-run --set apiToken=$CHT_API_TOKEN,clusterName=$CHT_CLUSTER_NAME,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.repository=latest-libs-06-13-3,image.pullPolicy=Never --set devArgs="\['upload_k8s_state_v4'\,'--verbose'\,'--endpoint'\,'http://<your_ip_address>:9292'\]" --set "customEnvVars[0].name=ENV4" --set "customEnvVars[0].value=VALUE4" --set serviceAccount.name=sample_service_account ./cloudhealth-collector-1.1.2.tgz

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -54,16 +54,15 @@ deployAnnotations: {}
 
 podAnnotations: {}
 
-podSecurityContext: {
+podSecurityContext:
   runAsNonRoot: true
-}
 
-containerSecurityContext: {
-  allowPrivilegeEscalation: false,
-  readOnlyRootFilesystem: true,
-  runAsNonRoot: true,
-  capabilities: {drop: [all]}
-}
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities: 
+    drop: [all]
 
 # -- Run the collector on the host network
 hostNetwork: false

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -27,7 +27,7 @@ jvmMemory: "-Xmx891M"
 
 image:
   repository: cloudhealth/container-collector
-  tag: "1480"
+  tag: "1481"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -27,7 +27,7 @@ jvmMemory: "-Xmx891M"
 
 image:
   repository: cloudhealth/container-collector
-  tag: "1458"
+  tag: "1480"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,7 +10,7 @@ The agent has been verified against:
 
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
-## [1480] - 2024-07-16
+## [1481] - 2024-07-18
 
 ### Security
 

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,7 +10,7 @@ The agent has been verified against:
 
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
-## [1481] - 2024-07-18
+## [1481] - 2024-07-19
 
 ### Security
 

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,6 +10,38 @@ The agent has been verified against:
 
 All versions before June 20, 2022 have been deprecated.
 
+## [1480] - 2024-07-16
+
+### Security
+
+* Vulnerabilities patched:
+  * [CVE-2023-5388](https://avd.aquasec.com/nvd/cve-2023-5388)
+  * [CVE-2023-46218](https://avd.aquasec.com/nvd/cve-2023-46218)
+  * [CVE-2023-46219](https://avd.aquasec.com/nvd/cve-2023-46219)
+  * [CVE-2024-2004](https://avd.aquasec.com/nvd/cve-2024-2004)
+  * [CVE-2024-2398](https://avd.aquasec.com/nvd/cve-2024-2398)
+  * [CVE-2024-2511](https://avd.aquasec.com/nvd/cve-2024-2511)
+  * [CVE-2024-2961](https://avd.aquasec.com/nvd/cve-2024-2961)
+  * [CVE-2024-4741](https://avd.aquasec.com/nvd/cve-2024-4741)
+  * [CVE-2024-5535](https://avd.aquasec.com/nvd/cve-2024-5535)
+  * [CVE-2024-26256](https://avd.aquasec.com/nvd/cve-2024-26256)
+  * [CVE-2024-26458](https://avd.aquasec.com/nvd/cve-2024-26458)
+  * [CVE-2024-26461](https://avd.aquasec.com/nvd/cve-2024-26461)
+  * [CVE-2024-26462](https://avd.aquasec.com/nvd/cve-2024-26462)
+  * [CVE-2024-28085](https://avd.aquasec.com/nvd/cve-2024-28085)
+  * [CVE-2024-28757](https://avd.aquasec.com/nvd/cve-2024-28757)
+  * [CVE-2024-28834](https://avd.aquasec.com/nvd/cve-2024-28834)
+  * [CVE-2024-28835](https://avd.aquasec.com/nvd/cve-2024-28835)
+  * [CVE-2024-29857](https://avd.aquasec.com/nvd/cve-2024-29857)
+  * [CVE-2024-30171](https://avd.aquasec.com/nvd/cve-2024-30171)
+  * [CVE-2024-30172](https://avd.aquasec.com/nvd/cve-2024-30172)
+  * [CVE-2024-33599](https://avd.aquasec.com/nvd/cve-2024-33599)
+  * [CVE-2024-33600](https://avd.aquasec.com/nvd/cve-2024-33600)
+  * [CVE-2024-33601](https://avd.aquasec.com/nvd/cve-2024-33601)
+  * [CVE-2024-33602](https://avd.aquasec.com/nvd/cve-2024-33602)
+  * [CVE-2024-34397](https://avd.aquasec.com/nvd/cve-2024-34397)
+  * [CVE-2024-34447](https://avd.aquasec.com/nvd/cve-2024-34447)
+
 ## [1458] - 2024-03-11
 
 ### Added

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -8,7 +8,7 @@ The agent has been verified against:
 [Kubernetes Versions ≤ 1.29](https://kubernetes.io/releases/)</br>
 [OC Version ≥ 4.1](https://docs.openshift.com/container-platform)
 
-All versions before June 20, 2022 have been deprecated.
+All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
 ## [1480] - 2024-07-16
 


### PR DESCRIPTION
JIRA Ticket: https://cloudhealthtech.atlassian.net/browse/SDO-3026

Vulnerabilities in Image # 1458
![screenshot-2024-07-15+22 01 30](https://github.com/user-attachments/assets/2d70848c-c447-4b42-bc3d-a6df6aa08ab7)

![screenshot-2024-07-15+22 02 21](https://github.com/user-attachments/assets/62ff1634-fa1f-4f50-9f22-1479b59b7e95)


Trivy Scan on latest image
![screenshot-2024-07-15+22 02 52](https://github.com/user-attachments/assets/a3b92810-2216-4c47-8388-0694e358d09b)

The Following Command worked on minikube successfully pulling the correct 1481 prod image:
`helm upgrade cloudhealth-collector --set apiToken=<token>,clusterName=gm-local-minikube ./cloudhealth-collector --debug -n dmz --create-namespace`
