### PR TITLE
[CLHC-224439] - Update Collector Image for Security Vulnerabilities and minor bug fix

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.6.5
-appVersion: "7.2.0"
+version: 4.6.6
+appVersion: "7.3.0"
 home: https://cloudhealth.vmware.com/
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg
 sources:

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -27,7 +27,7 @@ jvmMemory: "-Xmx891M"
 
 image:
   repository: cloudhealth/container-collector
-  tag: "1498"
+  tag: "1500"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,6 +10,19 @@ The agent has been verified against:
 
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
+## [1500] - 2025-04-16
+
+### Fixed
+
+* Minor bug fix on the log message formatting when posting the collected resources to CloudHealth.
+
+### Security
+
+* Vulnerabilities patched:
+  * [CVE-2024-8176](https://avd.aquasec.com/nvd/cve-2024-8176)
+  * [CVE-2025-27363](https://avd.aquasec.com/nvd/cve-2025-27363)
+  * [CVE-2025-31115](https://avd.aquasec.com/nvd/cve-2025-31115)
+
 ## [1498] - 2024-10-28
 
 ### Security


### PR DESCRIPTION
JIRA: [CLHC-219193](https://vmw-jira.broadcom.net/browse/CLHC-219193)

Vulnerabilities in image #1498:
<img width="1070" alt="Screenshot 2025-04-15 at 2 17 41 PM" src="https://github.com/user-attachments/assets/56109ddf-ba3b-446a-a186-6ad9f4d9d16b" />

Trivy Scan on latest image:
<img width="1638" alt="Screenshot 2025-04-16 at 1 32 01 PM" src="https://github.com/user-attachments/assets/6c41a2e4-93c5-429e-9d4f-daa260ea2769" />


Test using docker hub dev image:
```
helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=jdacruz-kind-local,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.tag=latest,image.repository=cloudhealth/container-collector-dev cloudhealth/cloudhealth-collector
```
<img width="2558" alt="Screenshot 2025-04-16 at 12 42 04 PM" src="https://github.com/user-attachments/assets/579e9bc0-9ac0-48ca-bfaa-e4c4f643ef65" />

Test using docker hub prod image:
```
helm install cloudhealth-collector --set apiToken=$CHT_API_TOKEN,clusterName=jdacruz-kind-prod-latest,chtEndpointPrefix=$CHT_ENDPOINT_PREFIX,image.tag=latest cloudhealth/cloudhealth-collector
```

<img width="2551" alt="Screenshot 2025-04-16 at 12 56 31 PM" src="https://github.com/user-attachments/assets/96f97656-cace-4a95-b8a3-3410850af6f0" />

