### PR TITLE
[CLHC-238528] - Update Collector Image for Security Vulnerabilities

### DIFF
--- a/charts/cloudhealth-collector/Chart.yaml
+++ b/charts/cloudhealth-collector/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 name: cloudhealth-collector
 description: A Helm chart for CloudHealth's Kubernetes Collector Agent
 type: application
-version: 4.6.6
-appVersion: "7.3.0"
+version: 4.6.7
+appVersion: "7.4.0"
 home: https://cloudhealth.vmware.com/
 icon: https://d1fto35gcfffzn.cloudfront.net/images/Tanzu-Logomark.svg
 sources:

--- a/charts/cloudhealth-collector/values.yaml
+++ b/charts/cloudhealth-collector/values.yaml
@@ -27,7 +27,7 @@ jvmMemory: "-Xmx891M"
 
 image:
   repository: cloudhealth/container-collector
-  tag: "1500"
+  tag: "1510"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -12,17 +12,6 @@ All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
 Here is the updated content in a clean code block, strictly following the .md structure and linking format of your original file.
 
-Markdown
-# Changelog
-
-All notable changes for each upgraded tag of the CloudHealth Container Collector image.  Found on DockerHub: https://hub.docker.com/r/cloudhealth/container-collector
-
-The agent has been verified against:
-
-[Kubernetes Versions ≥ 1.12](https://kubernetes.io/releases/)</br>
-[Kubernetes Versions ≤ 1.29](https://kubernetes.io/releases/)</br>
-[OC Version ≥ 4.1](https://docs.openshift.com/container-platform)
-
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
 ## [1510] - 2026-01-22

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -5,10 +5,67 @@ All notable changes for each upgraded tag of the CloudHealth Container Collector
 The agent has been verified against:
 
 [Kubernetes Versions ≥ 1.12](https://kubernetes.io/releases/)</br>
+[Kubernetes Versions ≤ 1.32](https://kubernetes.io/releases/)</br>
+[OC Version ≥ 4.1](https://docs.openshift.com/container-platform)
+
+All versions before June 20, 2022 (Version: 1191) have been deprecated.
+
+Here is the updated content in a clean code block, strictly following the .md structure and linking format of your original file.
+
+Markdown
+# Changelog
+
+All notable changes for each upgraded tag of the CloudHealth Container Collector image.  Found on DockerHub: https://hub.docker.com/r/cloudhealth/container-collector
+
+The agent has been verified against:
+
+[Kubernetes Versions ≥ 1.12](https://kubernetes.io/releases/)</br>
 [Kubernetes Versions ≤ 1.29](https://kubernetes.io/releases/)</br>
 [OC Version ≥ 4.1](https://docs.openshift.com/container-platform)
 
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
+
+## [1510] - 2026-01-22
+
+### Security
+
+* Vulnerabilities patched:
+  * [CVE-2024-3596](https://avd.aquasec.com/nvd/cve-2024-3596)
+  * [CVE-2025-5914](https://avd.aquasec.com/nvd/cve-2025-5914)
+  * [CVE-2025-5915](https://avd.aquasec.com/nvd/cve-2025-5915)
+  * [CVE-2025-5916](https://avd.aquasec.com/nvd/cve-2025-5916)
+  * [CVE-2025-5917](https://avd.aquasec.com/nvd/cve-2025-5917)
+  * [CVE-2025-5918](https://avd.aquasec.com/nvd/cve-2025-5918)
+  * [CVE-2025-60753](https://avd.aquasec.com/nvd/cve-2025-60753)
+  * [CVE-2025-4517](https://avd.aquasec.com/nvd/cve-2025-4517)
+  * [CVE-2025-4138](https://avd.aquasec.com/nvd/cve-2025-4138)
+  * [CVE-2025-4330](https://avd.aquasec.com/nvd/cve-2025-4330)
+  * [CVE-2025-8194](https://avd.aquasec.com/nvd/cve-2025-8194)
+  * [CVE-2024-12718](https://avd.aquasec.com/nvd/cve-2024-12718)
+  * [CVE-2025-6965](https://avd.aquasec.com/nvd/cve-2025-6965)
+  * [CVE-2025-7709](https://avd.aquasec.com/nvd/cve-2025-7709)
+  * [CVE-2025-29088](https://avd.aquasec.com/nvd/cve-2025-29088)
+  * [CVE-2025-9086](https://avd.aquasec.com/nvd/cve-2025-9086)
+  * [CVE-2025-10148](https://avd.aquasec.com/nvd/cve-2025-10148)
+  * [CVE-2025-4947](https://avd.aquasec.com/nvd/cve-2025-4947)
+  * [CVE-2025-5025](https://avd.aquasec.com/nvd/cve-2025-5025)
+  * [CVE-2025-0395](https://avd.aquasec.com/nvd/cve-2025-0395)
+  * [CVE-2025-4802](https://avd.aquasec.com/nvd/cve-2025-4802)
+  * [CVE-2025-8058](https://avd.aquasec.com/nvd/cve-2025-8058)
+  * [CVE-2025-9230](https://avd.aquasec.com/nvd/cve-2025-9230)
+  * [CVE-2025-9232](https://avd.aquasec.com/nvd/cve-2025-9232)
+  * [CVE-2025-32988](https://avd.aquasec.com/nvd/cve-2025-32988)
+  * [CVE-2025-32990](https://avd.aquasec.com/nvd/cve-2025-32990)
+  * [CVE-2025-32989](https://avd.aquasec.com/nvd/cve-2025-32989)
+  * [CVE-2025-6395](https://avd.aquasec.com/nvd/cve-2025-6395)
+  * [CVE-2025-59375](https://avd.aquasec.com/nvd/cve-2025-59375)
+  * [CVE-2024-10963](https://avd.aquasec.com/nvd/cve-2024-10963)
+  * [CVE-2025-6020](https://avd.aquasec.com/nvd/cve-2025-6020)
+  * [CVE-2025-13601](https://avd.aquasec.com/nvd/cve-2025-13601)
+  * [CVE-2025-4373](https://avd.aquasec.com/nvd/cve-2025-4373)
+  * [CVE-2025-6141](https://avd.aquasec.com/nvd/cve-2025-6141)
+  * [CVE-2025-8916](https://avd.aquasec.com/nvd/cve-2025-8916)
+  * [CVE-2025-46551](https://avd.aquasec.com/nvd/cve-2025-46551)
 
 ## [1500] - 2025-04-16
 

--- a/cloudhealth-collector-image-docs/CHANGELOG.md
+++ b/cloudhealth-collector-image-docs/CHANGELOG.md
@@ -10,10 +10,6 @@ The agent has been verified against:
 
 All versions before June 20, 2022 (Version: 1191) have been deprecated.
 
-Here is the updated content in a clean code block, strictly following the .md structure and linking format of your original file.
-
-All versions before June 20, 2022 (Version: 1191) have been deprecated.
-
 ## [1510] - 2026-01-22
 
 ### Security


### PR DESCRIPTION
JIRA Ticket: https://vmw-jira.broadcom.net/browse/CLHC-238528

Vulnerabilities in Image # 1500
<img width="1242" height="1251" alt="Screenshot 2026-01-22 at 11 12 14 AM" src="https://github.com/user-attachments/assets/f1622e4f-54dc-43b6-98af-6611b00a05cc" />
<img width="1086" height="1065" alt="Screenshot 2026-01-22 at 11 12 27 AM" src="https://github.com/user-attachments/assets/7f55dfd9-333d-4389-94c1-9f459a629114" />
<img width="1100" height="1051" alt="Screenshot 2026-01-22 at 11 12 40 AM" src="https://github.com/user-attachments/assets/482118a9-98ef-4434-96fb-d6dfa1ae9742" />
<img width="1306" height="879" alt="Screenshot 2026-01-22 at 11 13 10 AM" src="https://github.com/user-attachments/assets/278b9fda-15e4-4309-ad58-dc7a3bf62a3c" />

Trivy Scan on latest image
<img width="1025" height="398" alt="Screenshot 2026-01-22 at 11 15 33 AM" src="https://github.com/user-attachments/assets/112195c3-f837-42fb-afe9-dd82b1850382" />

New image tag on docker hub:
<img width="2311" height="1010" alt="Screenshot 2026-01-22 at 2 07 53 PM" src="https://github.com/user-attachments/assets/2c164aa9-3adf-4aeb-83e5-a7cc440db94c" />

The Following Command worked on minikube successfully pulling the correct 1510 prod image:
```
helm install cloudhealth-collector \
  --set apiToken=$CHT_API_TOKEN \
  --set clusterName=jdacruz-prod-test \
  --set chtEndpointPrefix=$CHT_ENDPOINT_PREFIX \
  --set-string image.tag=1510 \
  --set image.repository=docker.io/cloudhealth/container-collector \
  cloudhealth/cloudhealth-collector
```

Screenshot from cluster list for customer 2017:
<img width="2542" height="784" alt="Screenshot 2026-01-22 at 2 02 51 PM" src="https://github.com/user-attachments/assets/19a35dfa-2384-4adf-9049-0a52605c98fd" />

